### PR TITLE
added Item Filters to manual install list

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
     <a href="https://www.curseforge.com/minecraft/mc-mods/ftb-library-fabric">
       FTB Library ｜
     </a>
+    <a href="https://www.curseforge.com/minecraft/mc-mods/item-filters">
+      Item Filters ｜
+    </a>
     <a href="https://www.curseforge.com/minecraft/mc-mods/quests-additions-fabric">
       Quests Additions
     </a>


### PR DESCRIPTION
FTB Quests requires Item Filters to run properly. The user is prompted with a message on run requesting that they install Item Filters. This is not that big of a change, but it should be listed with the others for simplicity’s sake.