### PR TITLE
WIP: Extractor Machine: Fix returning from direction search

### DIFF
--- a/src/main/java/com/dm/earth/cabricality/content/extractor/ExtractorMachineBlockEntity.java
+++ b/src/main/java/com/dm/earth/cabricality/content/extractor/ExtractorMachineBlockEntity.java
@@ -128,8 +128,7 @@ public class ExtractorMachineBlockEntity extends BlockEntity implements IHaveGog
 							return 1.0F;
 					} else
 						debug("extractor block entity: not enough leaves at " + upPos.toShortString());
-				} else
-					return 0.0F;
+				}
 			}
 		}
 		return 0.0F;


### PR DESCRIPTION
There is an issue where if not enough logs are available in a given direction, the function prematurely returns 0f. This means that the extractor machine will only ever search for logs in a given direction. If there no logs in the first direction it searches in, it will just give up.

For some reason, I've had this order change even though Enum.values should be consistently the order declared. This means that suddenly my previously working extractor machine will simply stop working, and placing an extractor machine in a different direction will start working.