### PR TITLE
Fix: remove references to IdentifierBuilder

### DIFF
--- a/src/main/java/com/dm/earth/cabricality/ModEntry.java
+++ b/src/main/java/com/dm/earth/cabricality/ModEntry.java
@@ -1,13 +1,15 @@
 package com.dm.earth.cabricality;
 
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import com.simibubi.create.content.contraptions.processing.ProcessingOutput;
 
-import net.krlite.equator.util.IdentifierBuilder;
 import net.minecraft.block.Block;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.item.Item;
@@ -86,7 +88,7 @@ public enum ModEntry {
 	}
 
 	public Identifier id(String... path) {
-		return new IdentifierBuilder.Specified(this.modId).id(path);
+		return new Identifier(this.modId, String.join("/", path));
 	}
 
 	public Item asItem(String... paths) {

--- a/src/main/java/com/dm/earth/cabricality/ModEntry.java
+++ b/src/main/java/com/dm/earth/cabricality/ModEntry.java
@@ -1,9 +1,6 @@
 package com.dm.earth.cabricality;
 
-import java.util.Arrays;
-import java.util.Objects;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/com/dm/earth/cabricality/client/plugin/rei/CabfREIClientPlugin.java
+++ b/src/main/java/com/dm/earth/cabricality/client/plugin/rei/CabfREIClientPlugin.java
@@ -39,7 +39,6 @@ import me.shedaniel.rei.api.common.entry.EntryStack;
 import me.shedaniel.rei.api.common.entry.type.EntryType;
 import me.shedaniel.rei.api.common.entry.type.VanillaEntryTypes;
 import me.shedaniel.rei.api.common.util.EntryIngredients;
-import net.krlite.equator.util.IdentifierBuilder;
 import net.minecraft.item.Items;
 import net.minecraft.tag.TagKey;
 import net.minecraft.text.TranslatableText;
@@ -88,6 +87,10 @@ public class CabfREIClientPlugin implements REIClientPlugin {
 				.orElse(subs[0]);
 	}
 
+	private TranslatableText convertToTranslatableText(String prefix, Identifier identifier) {
+		return new TranslatableText(prefix + "." + identifier.getNamespace() + "." + String.join(".", identifier.getPath()));
+	}
+
 	/**
 	 * Gets a {@link TranslatableText} from the given {@link Identifier}, prefixed
 	 * with <code>"tag"</code>.
@@ -96,7 +99,7 @@ public class CabfREIClientPlugin implements REIClientPlugin {
 	 * @return The tagged text.
 	 */
 	private TranslatableText tag(Identifier identifier) {
-		return new IdentifierBuilder.Specified(identifier.getNamespace()).localization("tag", identifier.getPath());
+		return convertToTranslatableText("tag", identifier);
 	}
 
 	/**
@@ -107,7 +110,7 @@ public class CabfREIClientPlugin implements REIClientPlugin {
 	 * @return The coled text.
 	 */
 	private TranslatableText col(Identifier identifier) {
-		return new IdentifierBuilder.Specified(identifier.getNamespace()).localization("col", identifier.getPath());
+		return convertToTranslatableText("col", identifier);
 	}
 
 	private static final String[] COLORS = {

--- a/src/main/java/com/dm/earth/cabricality/network/CabfNetworking.java
+++ b/src/main/java/com/dm/earth/cabricality/network/CabfNetworking.java
@@ -1,13 +1,10 @@
 package com.dm.earth.cabricality.network;
 
 import com.dm.earth.cabricality.Cabricality;
-import net.krlite.equator.util.IdentifierBuilder;
 import net.minecraft.util.Identifier;
 
 // Networking keys
 public class CabfNetworking {
-	private static final IdentifierBuilder.Specified ID_BUILDER = new IdentifierBuilder.Specified(Cabricality.ID + "_networking");
-
 	// Commands
-	public static final Identifier HELD_ITEM_INFO = ID_BUILDER.id("command", "held_item_info");
+	public static final Identifier HELD_ITEM_INFO = new Identifier(Cabricality.ID + "_networking", "held_item_info");
 }


### PR DESCRIPTION
In the commit https://github.com/DM-Earth/Cabricality/commit/e2cb4371bbac6900ab4708f2fe53048b1b277d13, equator was removed in favour of equator-v2. However, references to a class IdentifierBuilder was left in the Cabricality code. IdentifierBuilder only exists in equator, and there is no equivalent in equator-v2. As such, as builds following this commit have failed as the namespace is missing.

This PR changes the previous IdentifierBuilder syntactic sugar to just manually written code. There were only four references to IdentifierBuilder, and the use of an external library for them seems a bit overkill. With this fix, the project can actually be built again.