### PR TITLE
Change infusing recipe of wither proof obsidian

### DIFF
--- a/src/main/resources/resourcepacks/data_overrides/data/indrev/recipes/fluid_infusing/wither_proof_obsidian.json
+++ b/src/main/resources/resourcepacks/data_overrides/data/indrev/recipes/fluid_infusing/wither_proof_obsidian.json
@@ -1,0 +1,17 @@
+{
+  "type": "indrev:fluid_infuse",
+  "ingredients": [
+    {
+      "item": "minecraft:obsidian"
+    }
+  ],
+  "fluidInput": {
+    "fluid": "tconstruct:molten_iron",
+    "amount": 81000
+  },
+  "output": {
+    "item": "indrev:wither_proof_obsidian",
+    "count": 1
+  },
+  "processTime": 400
+}


### PR DESCRIPTION
Previous recipe needs "indrev:molten_iron_still" , which is disabled in survival mode. Please use "tconstruct:molten_iron" instead.